### PR TITLE
修复 sendSingleMessage 方法

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ export default class JMessage {
     return JMessageModule.logout();
   }
   static sendSingleMessage({name, type, data={}}) {
-    return JMessageModule.sendSingleMessage(name, type, data)
+    return JMessageModule.sendSingleMessage(JMessage.appKey, name, type, data)
       .then(message => formatMessage(message));
   }
   static sendGroupMessage({gid, type, data={}}) {


### PR DESCRIPTION
修复单个信息接口报错：需要四个参数，但只传递了三个的问题